### PR TITLE
adjust rig parameters

### DIFF
--- a/configs/rig/rig2.yaml
+++ b/configs/rig/rig2.yaml
@@ -22,7 +22,7 @@ haptic:
     # Optional: tune heartbeat/timeout; defaults are fine for local IPC.
     heartbeat_interval_s: 0.2
     command_timeout_ms: 1000
-    effector_mass_kg: 0.4  # stock handle + safety shield — weigh and adjust
+    effector_mass_kg: 0.35  # stock handle + safety shield — adjust via trial and error whenever handle changes
 
 display:
   backend: psychopy  # real PsychoPy window for the rig monitor
@@ -33,7 +33,7 @@ display:
   background_color: [0.0, 0.0, 0.0]
   # Horizontal mirror compensates for a canted mirror that reflects
   # the image left-right before it reaches the subject's eyes.
-  mirror_horizontal: true
+  mirror_horizontal: false
   mirror_vertical: false
 
 recording:
@@ -46,7 +46,7 @@ recording:
   #   trellis_data_dir: "data"
 
 sync:
-  backend: "teensy"  # one of: mock | teensy
+  backend: "mock"  # one of: mock | teensy
   sync_pulse_rate_hz: 1.0
   code_map:
     state_codes: {}


### PR DESCRIPTION
Adjusts a few rig parameters after testing gravity compensation. 

Switch to mock sync until Teensy is up and running, and swap monitor mirroring now that we have a forward-facing monitor.